### PR TITLE
Change codeowners for digitalSTROM binding

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -63,7 +63,7 @@
 /bundles/org.openhab.binding.deconz/ @openhab/add-ons-maintainers
 /bundles/org.openhab.binding.denonmarantz/ @jwveldhuis
 /bundles/org.openhab.binding.digiplex/ @rmichalak
-/bundles/org.openhab.binding.digitalstrom/ @MichaelOchel @msiegele
+/bundles/org.openhab.binding.digitalstrom/ @openhab/add-ons-maintainers
 /bundles/org.openhab.binding.dlinksmarthome/ @MikeJMajor
 /bundles/org.openhab.binding.dmx/ @openhab/add-ons-maintainers
 /bundles/org.openhab.binding.doorbird/ @mhilbush


### PR DESCRIPTION
to openhab/add-ons-maintainers as @MichaelOchel @msiegele have left the project.

Signed-off-by: Hans-Jörg Merk github@hmerk.de

